### PR TITLE
fix deprecation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest"] # skip macos-latest; https://github.com/s-weigand/setup-conda/issues/432
     steps:
       - uses: actions/checkout@v2
       - uses: s-weigand/setup-conda@v1

--- a/MEAutility/tests/test_core.py
+++ b/MEAutility/tests/test_core.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 from MEAutility.core import Electrode
 import MEAutility as mu
@@ -76,17 +75,17 @@ def test_are_points_inside():
 
     points = [[100, 105, 95], [100, 105, 105], [100, 105, 85]]
     print(elec_c.are_points_inside(points))
-    assert np.alltrue(elec_c.are_points_inside(points) == np.array([True, True, False]))
+    assert np.all(elec_c.are_points_inside(points) == np.array([True, True, False]))
 
     elec_s = Electrode(position=[100, 100, 100], normal=[1, 0, 0], size=10, shape='square',
                        sigma=[0.3, 0.4, 0.5], main_axes=[[0, 1, 0], [0, 0, 1]])
     points = [[100, 104, 96], [100, 104, 104], [100, 105, 85]]
-    assert np.alltrue(elec_s.are_points_inside(points) == np.array([True, True, False]))
+    assert np.all(elec_s.are_points_inside(points) == np.array([True, True, False]))
 
     elec_r = Electrode(position=[100, 100, 100], normal=[1, 0, 0], size=[10, 20], shape='rect',
                        sigma=[0.3, 0.4, 0.5], main_axes=[[0, 1, 0], [0, 0, 1]])
     points = [[100, 96, 114], [100, 104, 104], [100, 85, 105]]
-    assert np.alltrue(elec_r.are_points_inside(points) == np.array([True, True, False]))
+    assert np.all(elec_r.are_points_inside(points) == np.array([True, True, False]))
 
 
 def test_return_mea():

--- a/MEAutility/version.py
+++ b/MEAutility/version.py
@@ -1,1 +1,1 @@
-version = '1.5.1'
+version = '1.5.2'


### PR DESCRIPTION
fix `np.alltrue` -> `np.all`. Bumped version number. 
Closes #41. 